### PR TITLE
Fix failing unit tests

### DIFF
--- a/Test/Unit/Email/Log/SaveEmailLogTest.php
+++ b/Test/Unit/Email/Log/SaveEmailLogTest.php
@@ -182,6 +182,11 @@ class SaveEmailLogTest extends \PHPUnit\Framework\TestCase
     public $logs;
 
     /**
+     * @var \KiwiCommerce\EnhancedSMTP\Helper\Benchmark
+     */
+    public $benchmark;
+
+    /**
      * @var SaveEmailLog
      */
     public $saveEmailLog;
@@ -238,6 +243,10 @@ class SaveEmailLogTest extends \PHPUnit\Framework\TestCase
             'save'
         ]);
 
+        $this->benchmark = $this->getMockBuilder(\KiwiCommerce\EnhancedSMTP\Helper\Benchmark::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->saveEmailLog = new SaveEmailLog(
             $this->templateFactory,
             $this->message,
@@ -249,7 +258,8 @@ class SaveEmailLogTest extends \PHPUnit\Framework\TestCase
             $this->requests,
             $this->config,
             $this->status,
-            $this->logger
+            $this->logger,
+            $this->benchmark
         );
     }
 

--- a/Test/Unit/Email/TransportTest.php
+++ b/Test/Unit/Email/TransportTest.php
@@ -55,6 +55,11 @@ class TransportTest extends \PHPUnit\Framework\TestCase
     public $status;
 
     /**
+     * @var \KiwiCommerce\EnhancedSMTP\Helper\Benchmark
+     */
+    public $benchmark;
+
+    /**
      * @var \Magento\Framework\Mail\TransportInterface
      */
     public $transportInterface;
@@ -88,13 +93,18 @@ class TransportTest extends \PHPUnit\Framework\TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->benchmark = $this->getMockBuilder(\KiwiCommerce\EnhancedSMTP\Helper\Benchmark::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->transportInterface = $this->createMock(\Magento\Framework\Mail\TransportInterface::class);
         $this->zendMailMock =  $this->createMock(\Zend_Mail::class);
 
         $this->transport = new Transport(
             $this->config,
             $this->logger,
-            $this->status
+            $this->status,
+            $this->benchmark
         );
     }
 


### PR DESCRIPTION
This is a fix to unit tests which are failing due to classes under test being instantiated with incorrect number of parameters.